### PR TITLE
Replace `ImageMode` API when running under qbicc

### DIFF
--- a/runtime/src/main/java/org/qbicc/quarkus/runtime/patch/ImageMode$_patch.java
+++ b/runtime/src/main/java/org/qbicc/quarkus/runtime/patch/ImageMode$_patch.java
@@ -1,0 +1,20 @@
+package org.qbicc.quarkus.runtime.patch;
+
+import io.quarkus.runtime.ImageMode;
+import org.qbicc.runtime.Build;
+import org.qbicc.runtime.patcher.Patch;
+import org.qbicc.runtime.patcher.Replace;
+
+@Patch(ImageMode.class)
+final class ImageMode$_patch {
+    @Replace
+    static ImageMode current() {
+        if (Build.isHost()) {
+            return ImageMode.NATIVE_BUILD;
+        } else if (Build.isTarget()) {
+            return ImageMode.NATIVE_RUN;
+        } else {
+            return ImageMode.JVM;
+        }
+    }
+}

--- a/runtime/src/main/resources/META-INF/qbicc/qbicc-patch-info
+++ b/runtime/src/main/resources/META-INF/qbicc/qbicc-patch-info
@@ -1,0 +1,1 @@
+org.qbicc.quarkus.runtime.patch.ImageMode$_patch


### PR DESCRIPTION
Depends on [quarkus #29993](https://github.com/quarkusio/quarkus/pull/29993).