### PR TITLE
define GitHub action for CI

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,83 @@
+name: quarkus-qbiccs Continuous Integration
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+      - '**.adoc'
+    branches: [ main ]
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - '**.adoc'
+    branches: [ main ]
+    types: [ opened, synchronize, reopened ]
+jobs:
+  build-matrix:
+    name: "Matrix build"
+    strategy:
+      fail-fast: false
+      matrix:
+        llvm-version: ["15"]
+        os: [ubuntu-latest, macos-latest]
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Install LLVM
+        uses: KyleMayes/install-llvm-action@v1.6.1
+        with:
+          version: ${{ matrix.llvm-version }}
+          directory: ${{ runner.temp }}/llvm-install
+
+      - name: Install `libgcc` (Linux only)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get install -y libgcc-11-dev
+
+      - name: Install libunwind (Linux only)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get install -y libunwind-dev
+
+      - name: Install OpenJDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      # Temporary: avoid quarkus issues with maven >= 3.8.x
+      - name: Set up Maven
+        uses: stCarolas/setup-maven@v4.5
+        with:
+          maven-version: 3.8.7
+
+      - name: Clone project
+        uses: actions/checkout@v3
+        with:
+          path: quarkus-qbicc
+          submodules: recursive
+
+      - name: Build extension
+        run: |
+          mvn --batch-mode install
+        working-directory: quarkus-qbicc
+
+      - name: Clone knative-quarkus-bench
+        uses: actions/checkout@v3
+        with:
+          repository: ibm/knative-quarkus-bench
+          path: knative-quarkus-bench
+
+      - name: Compile sleep benchmark
+        env:
+          MAVEN_OPTS: -Xss8m -Xms1024M -Xmx4096M
+        run: |
+          mvn --batch-mode package -Dquarkus.container-image.build=false -Pqbicc
+        working-directory: knative-quarkus-bench/benchmarks/sleep
+
+      - name: Run sleep benchmark
+        # TODO: Disabled on macos because it isn't working in the CI environment (not sure why..)
+        if: matrix.os != 'macos-latest'
+        run: ./quarkus-qbicc/.github/workflows/testSleep.sh
+        env:
+          QUARKUS_HTTP_HOST: 127.0.0.1
+          QUARKUS_HTTP_PORT: 8081

--- a/.github/workflows/testSleep.sh
+++ b/.github/workflows/testSleep.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -meu
+
+# run background_job_gpid test_command
+run () {
+    PID=$1
+    shift
+    CODE=0
+    "$@" || CODE=$?
+    kill -- -$PID || true
+    sleep 1
+    return $CODE
+}
+
+echo "*** Testing Sleep Benchmark ***"
+
+./knative-quarkus-bench/benchmarks/sleep/target/native-sleep-1.0.0-SNAPSHOT/sleep-1.0.0-SNAPSHOT-runner &
+run $! curl --retry-connrefused --max-time 120 --retry 10 --retry-delay 3 -s -w "\n" -H 'Content-Type:application/json' -d '"test"' -X POST http://$QUARKUS_HTTP_HOST:$QUARKUS_HTTP_PORT/sleep

--- a/.github/workflows/testSleepJVM.sh
+++ b/.github/workflows/testSleepJVM.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -meu
+
+# run background_job_gpid test_command
+run () {
+    PID=$1
+    shift
+    CODE=0
+    date
+    echo "executing command: $@"
+    "$@" || CODE=$?
+    date
+    kill -- -$PID || true
+    sleep 1
+    return $CODE
+}
+
+echo "*** Testing Sleep Benchmark on JVM ***"
+
+java -jar ./knative-quarkus-bench/benchmarks/sleep/target/quarkus-app/quarkus-run.jar &
+run $! curl --retry-connrefused --max-time 60 --retry 10 --retry-delay 3 -s -w "\n" -H 'Content-Type:application/json' -d '"test"' -X POST http://$QUARKUS_HTTP_HOST:$QUARKUS_HTTP_PORT/sleep

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.version>2.16.5.Final</quarkus.version>
         <surefire-plugin.version>3.0.0</surefire-plugin.version>
-        <qbicc.version>0.69.0</qbicc.version>
+        <qbicc.version>0.70.0</qbicc.version>
     </properties>
 
     <dependencyManagement>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -23,21 +23,6 @@
             <artifactId>qbicc-runtime-api</artifactId>
             <version>${qbicc.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.qbicc</groupId>
-            <artifactId>qbicc-runtime-posix</artifactId>
-            <version>${qbicc.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.qbicc</groupId>
-            <artifactId>qbicc-runtime-linux</artifactId>
-            <version>${qbicc.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.qbicc</groupId>
-            <artifactId>qbicc-runtime-bsd</artifactId>
-            <version>${qbicc.version}</version>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
To start with, just compile one benchmark (knative-quarkus-bench sleep).

We should be able to enable actually running the code successfully on MacOS after 3 more releases (qbicc, qbicc-class-lib, qbicc) to propagate a needed fix for running on a clean system.

Running on Linux needs at least epoll fixes that are still being developed, so will take longer.

In the long run, probably makes most sense to use something from the quarkus-quickstart repo of sleep.   Compiling one application on a GitHub action runner takes about 15 minutes, so its probably not reasonable (at least right now) to compile more than one.
